### PR TITLE
Update password_auth_client_id input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
   test-action:
     name: GitHub Actions Test
     runs-on: ubuntu-latest
+    env:
+      SKIP_TOKEN_CACHE: 'true'
+      DEBUG: '*'
 
     steps:
       - name: Checkout
@@ -69,8 +72,6 @@ jobs:
           image: ${{ steps.image.outputs.image_id }}
           comment_on_pr: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: '*'
 
       - name: Test Action - experiences
         id: test-action-exp
@@ -80,6 +81,7 @@ jobs:
           auth0_tenant_url: 'https://resim-dev.us.auth0.com/'
           resim_username: 'resim.ai'
           resim_password: ${{ secrets.RESIM_PASSWORD }}
+          password_auth_client_id: "LLNl3xsbNLSd16gQyYsiEn3tbLDZo1gj"
           project: github-action-testing
           system: actions
           experiences: actions experience-a,"actions experience-b"
@@ -87,8 +89,6 @@ jobs:
           comment_on_pr: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
           metrics_build_id: 9168415c-a6ea-4425-aead-11a7894d60c1
-        env:
-          DEBUG: '*'
 
       - name: Test Action - test suites
         id: test-action-suites
@@ -104,8 +104,7 @@ jobs:
           image: ${{ steps.image.outputs.image_id }}
           comment_on_pr: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: '*'
+
       - name: Test Action - project doesn't exist
         id: test-action-no-proj
         continue-on-error: true
@@ -121,8 +120,6 @@ jobs:
           image: ${{ steps.image.outputs.image_id }}
           comment_on_pr: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: '*'
 
       - name: Test Action - no auth set
         id: test-action-no-auth
@@ -137,5 +134,3 @@ jobs:
           image: ${{ steps.image.outputs.image_id }}
           comment_on_pr: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          DEBUG: '*'

--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ inputs:
   auth0_tenant_url:
     required: true
     default: 'https://resim.us.auth0.com/'
-  password_client_id:
+  password_auth_client_id:
     required: true
     default: '0Ip56H1LLAo6Dc6IfePaNzgpUxbJGyVI'
   resim_username:

--- a/dist/index.js
+++ b/dist/index.js
@@ -64495,7 +64495,7 @@ async function getToken() {
     let token = '';
     let tokenValid = false;
     const cacheKey = await cache.restoreCache([tokenPath], '', ['resim-token-', 'resim-token']);
-    if (cacheKey) {
+    if (cacheKey !== undefined && process.env['SKIP_TOKEN_CACHE'] !== 'true') {
         token = await promises_1.default.readFile('.resimtoken', 'utf8');
         const options = {
             method: 'GET',

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,7 +33,7 @@ export async function getToken(): Promise<string> {
     ['resim-token-', 'resim-token']
   )
 
-  if (cacheKey) {
+  if (cacheKey !== undefined && process.env['SKIP_TOKEN_CACHE'] !== 'true') {
     token = await fs.readFile('.resimtoken', 'utf8')
 
     const options: AxiosRequestConfig = {


### PR DESCRIPTION
## Description of change

`action.yaml` defines it as `password_client_id`, the .ts implementation looks for `password_auth_client_id`. This means authentication fails as no client ID is passed through.

Also fixes CI that was masking this issue.

## Asana task link

[Asana task](<!-- Enter task link here -->)

## Guide to reproduce test results.
<!-- 
    Please help reviewers by including instructions 
    on how to test this change
-->
## Checklist:
- [ ] I have self-reviewed this change.
- [ ] I have tested this change.
- [ ] This change is covered by tests that are already landed, or in this PR.
